### PR TITLE
fix(showroom): onPress handling for closing drawer

### DIFF
--- a/src/app/(app)/(tabs)/showroom.tsx
+++ b/src/app/(app)/(tabs)/showroom.tsx
@@ -15,7 +15,7 @@ const logo = require("assets/images/logo.png")
 interface DemoListItem {
   item: { name: string; useCases: string[] }
   sectionIndex: number
-  handleScroll?: (sectionIndex: number, itemIndex?: number) => void
+  onPress?: () => void
 }
 
 const slugify = (str: string) =>
@@ -26,12 +26,12 @@ const slugify = (str: string) =>
     .replace(/[\s_-]+/g, "-")
     .replace(/^-+|-+$/g, "")
 
-const ShowroomListItem: FC<DemoListItem> = ({ item, sectionIndex }) => {
+const ShowroomListItem: FC<DemoListItem> = ({ item, sectionIndex, onPress }) => {
   const sectionSlug = item.name.toLowerCase()
 
   return (
     <View>
-      <Link href={{ pathname: "/showroom", params: { sectionSlug } }}>
+      <Link href={{ pathname: "/showroom", params: { sectionSlug } }} onPress={onPress}>
         <Text preset="bold">{item.name}</Text>
       </Link>
       {item.useCases.map((u) => {
@@ -41,6 +41,7 @@ const ShowroomListItem: FC<DemoListItem> = ({ item, sectionIndex }) => {
             key={`section${sectionIndex}-${u}`}
             href={{ pathname: "/showroom", params: { sectionSlug, itemSlug } }}
             asChild
+            onPress={onPress}
           >
             <ListItem text={u} rightIcon={isRTL ? "caretLeft" : "caretRight"} />
           </Link>
@@ -97,7 +98,6 @@ export default function DemoShowroomScreen() {
       itemIndex,
       sectionIndex,
     })
-    toggleDrawer()
   }
 
   const scrollToIndexFailed = (info: {
@@ -146,7 +146,7 @@ export default function DemoShowroomScreen() {
             }))}
             keyExtractor={(item) => item.name}
             renderItem={({ item, index: sectionIndex }) => (
-              <ShowroomListItem {...{ item, sectionIndex, handleScroll }} />
+              <ShowroomListItem {...{ item, sectionIndex, onPress: toggleDrawer }} />
             )}
           />
         </View>


### PR DESCRIPTION
Fixes max depth exceeded run away useEffect when interacting with the showroom drawer

Didn't want to add onPress necessarily as to show off Link href, but still has the proper routing and URLs, just cleans up the drawer nicer