### PR TITLE
feat(select-field): add `searchable` prop [DON'T MERGE, just for comparison]

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   },
   "dependencies": {
     "@expo-google-fonts/space-grotesk": "^0.2.2",
+    "@expo/vector-icons": "^14.0.0",
     "@gorhom/bottom-sheet": "^4.6.1",
     "@react-native-async-storage/async-storage": "1.23.1",
     "@react-navigation/bottom-tabs": "^6.3.2",


### PR DESCRIPTION
## Description
- Adds `searchable` boolean to `SelectField`
- Provides a `TextField` for user to search the list in

## Notes
- Possibly a good candidate to add `react-native-keyboard-controller` to have finer grain control over it's disappearing etc

## Screenshots

https://github.com/infinitered/cr-2024-intermediate-workshop-template/assets/374022/981a8d1f-5da1-4330-83cc-3ce82c3200fc