### PR TITLE
fix(profile): theme toggle

### DIFF
--- a/src/app/(app)/(tabs)/profile.tsx
+++ b/src/app/(app)/(tabs)/profile.tsx
@@ -22,7 +22,8 @@ export default observer(function ProfileScreen() {
     [logout],
   )
 
-  const { name, location, yoe, bio, openToWork, remote, skills, rnFamiliarity, setProp } = profile
+  const { name, location, yoe, bio, openToWork, remote, darkMode, skills, rnFamiliarity, setProp } =
+    profile
 
   return (
     <Screen preset="scroll" contentContainerStyle={$container} keyboardShouldPersistTaps="handled">
@@ -97,6 +98,14 @@ export default observer(function ProfileScreen() {
         value={remote}
         onPress={() => setProp("remote", !remote)}
       />
+      <Toggle
+        labelTx="demoProfileScreen.darkMode"
+        variant="switch"
+        labelPosition="left"
+        containerStyle={$textField}
+        value={darkMode}
+        onPress={() => setProp("darkMode", !darkMode)}
+      />
       <Text preset="formLabel" tx="demoProfileScreen.skills" />
       <TextField
         value={skills}
@@ -115,7 +124,7 @@ export default observer(function ProfileScreen() {
       <Button
         tx="demoProfileScreen.submitButton"
         preset="filled"
-        onPress={() => console.log("Validaiton done. Submitting to API.")}
+        onPress={() => console.log("Validation done. Submitting to API.")}
       />
     </Screen>
   )

--- a/src/app/(app)/(tabs)/profile.tsx
+++ b/src/app/(app)/(tabs)/profile.tsx
@@ -122,7 +122,6 @@ export default observer(function ProfileScreen() {
 })
 
 const $container: ViewStyle = {
-  paddingTop: spacing.lg + spacing.xl,
   paddingBottom: spacing.lg,
   paddingHorizontal: spacing.lg,
 }

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -84,6 +84,7 @@ const en = {
     location: "Location",
     job: "Looking for a job?",
     remote: "Remote only?",
+    darkMode: "Prefer dark mode?",
     bio: "Bio",
     yoe: "Years of Experience",
     rnFamiliarity: "React Native Familiarity",

--- a/src/models/Profile.ts
+++ b/src/models/Profile.ts
@@ -15,6 +15,7 @@ export const ProfileModel = types
     remote: types.optional(types.boolean, false),
     skills: "",
     rnFamiliarity: types.optional(types.number, 0),
+    darkMode: types.optional(types.boolean, false),
   })
   .actions(withSetPropAction)
 


### PR DESCRIPTION
## Description
- Adds another toggle to the profile screen to later wire up in the theming exercise
- Fixes padding for the Profile screen now that the Logout button is there, things got pushed down

## Screenshots
| Podcast    | Profile After | Profile Before |
| -------- | ------- | ------- |
| <img src="https://github.com/infinitered/cr-2024-intermediate-workshop-template/assets/374022/47aebcbb-d0fa-41c8-a434-c9ba04af4749" width="300" />  | <img src="https://github.com/infinitered/cr-2024-intermediate-workshop-template/assets/374022/dd6a26ba-21ca-488c-bf87-2a9542ca8271" width="300" />  | <img src="https://github.com/infinitered/cr-2024-intermediate-workshop-template/assets/374022/e081707a-8557-4862-a736-25cb5893179b" width="300" /> |





